### PR TITLE
Add basic geometric extrusion outlines

### DIFF
--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -5,7 +5,7 @@ use libprim::{
         shape_cycle::{animation_system_set, Animation, AnimationBundle, TimePoint},
         tween::{tween_system_set, Tween, TweenState, Tweening, Tweens},
     },
-    instance::{Instance2D, InstanceBundle},
+    instance::{Instance2D, InstanceBundle, Outline},
     shape_registry::ShapeRegistry,
     window::PrimWindowOptions,
 };
@@ -72,6 +72,10 @@ fn run_animation() {
             .insert_bundle(InstanceBundle::new(Instance2D {
                 shape: line,
                 scale: Vec2::splat(500.0),
+                outline: Some(Outline {
+                    scale: 55.0,
+                    color: Vec4::ONE,
+                }),
                 ..Default::default()
             }))
             .insert_bundle(AnimationBundle::from_animation(Animation::new(

--- a/examples/space_invaders.rs
+++ b/examples/space_invaders.rs
@@ -109,6 +109,7 @@ pub fn fire(
                         scale: Vec2::splat(25.0),
                         color: Vec4::new(1.0, 0.0, 0.0, 1.0),
                         shape: rocket_id,
+                        outline: None,
                     }))
                     .insert(PlayerFire)
                     .insert(Collidable)
@@ -256,6 +257,7 @@ fn spawn_world(
             scale: Vec2::splat(50.0),
             color: Vec4::ONE,
             shape: 1,
+            outline: None,
         }))
         .insert(Player)
         .insert(MoveSpeed(345.0))
@@ -272,6 +274,7 @@ fn spawn_world(
                 scale: Vec2::new(100.0, 50.0),
                 color: Vec4::new(0.7, 0.7, 0.7, 1.0),
                 shape: house_id,
+                outline: None,
             }));
     }
 
@@ -294,6 +297,7 @@ fn spawn_world(
                     scale: Vec2::splat(35.0),
                     color: Vec4::new(0.25, 0.9, 0.6, 1.0),
                     shape: 1,
+                    outline: None,
                 }))
                 .insert(Enemy)
                 .insert(Collidable)

--- a/src/collision.rs
+++ b/src/collision.rs
@@ -291,6 +291,7 @@ mod tests {
             scale: Vec2::splat(35.0),
             color: Vec4::ZERO,
             shape: 0,
+            outline: None,
         };
 
         let b = Instance2D {
@@ -299,6 +300,7 @@ mod tests {
             scale: Vec2::splat(50.0),
             color: Vec4::ZERO,
             shape: 0,
+            outline: None,
         };
 
         let c = Instance2D {
@@ -307,6 +309,7 @@ mod tests {
             scale: Vec2::splat(10.0),
             color: Vec4::ZERO,
             shape: 0,
+            outline: None,
         };
 
         assert!(overlapping(&a, &b));

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -8,6 +8,7 @@ pub struct Instance2D {
     pub scale: Vec2,
     pub color: Vec4,
     pub shape: u32,
+    pub outline: Option<Outline>,
 }
 
 impl Default for Instance2D {
@@ -18,6 +19,7 @@ impl Default for Instance2D {
             scale: Vec2::ONE,
             color: Vec4::ONE,
             shape: 0,
+            outline: None,
         }
     }
 }
@@ -71,6 +73,7 @@ impl Instance2D {
         scale: Vec2,
         color: Vec4,
         shape: u32,
+        outline: Option<Outline>,
     ) -> Self {
         Self {
             position,
@@ -78,6 +81,7 @@ impl Instance2D {
             scale,
             color,
             shape,
+            outline,
         }
     }
 
@@ -92,6 +96,19 @@ impl Instance2D {
             )),
             color: self.color,
         }
+    }
+
+    #[inline(always)]
+    #[must_use]
+    pub fn outline_matrix(&self) -> Option<Inst> {
+        self.outline.map(|outline| Inst {
+            transform: Mat4::from_mat3(Mat3::from_scale_angle_translation(
+                self.scale * 1.0 + outline.scale,
+                self.rotation,
+                self.position,
+            )),
+            color: outline.color,
+        })
     }
 }
 
@@ -116,4 +133,10 @@ impl InstanceBundle {
             inst: instance.to_matrix(),
         }
     }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Outline {
+    pub scale: f32,
+    pub color: Vec4,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use bevy_ecs::{
 use glam::{Vec2, Vec3, Vec4};
 use libprim::{
     initialization::InitializeCommand,
-    instance::{Instance2D, InstanceBundle},
+    instance::{Instance2D, InstanceBundle, Outline},
     run,
     state::FpsDisplayBundle,
     text::InitializeFont,
@@ -92,6 +92,10 @@ fn spinner_spawn(mut commands: Commands) {
                         1.0,
                     ),
                     shape: u32::from((x + y) % 2 == 0),
+                    outline: Some(Outline {
+                        scale: 5.0,
+                        color: Vec4::ZERO,
+                    }),
                 }))
                 .insert(SpinMultiplier(rng.gen_range(0.2..2.0)));
         }

--- a/src/state.rs
+++ b/src/state.rs
@@ -454,6 +454,9 @@ fn collect_instances(
             && inst.position.y - inst.scale.y < camera2d.position.y + camera2d.scale.y
             && inst.position.y + inst.scale.y > camera2d.position.y - camera2d.scale.y
         {
+            if let Some(outline_inst) = inst.outline_matrix() {
+                renderables.0.push((*inst, outline_inst));
+            }
             renderables.0.push((*inst, *render_inst));
         }
     }


### PR DESCRIPTION
Adds the ability for shapes to have an outline through geometric extrusion.

This is a simple but not necessarily perfect method as any shape with an outline is effectively two shapes, as we render a slightly larger shape underneath in the outline color, which can have a tangible impact on performance when there are a lot of shapes with outlines. We are also currently recomputing outline matrices for every frame, which isn't entirely necessary and can be optimized later.